### PR TITLE
Update db_instance_class to db_instance_type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1084,7 +1084,7 @@ variable "db_engine_version" {
 }
 
 ## Database Instance Class
-variable "db_instance_class" {
+variable "db_instance_type" {
   type        = string
   default     = "db.r5.xlarge"
   description = "The instance class for the database."


### PR DESCRIPTION
It would be nicer to rename `db_instance_class` to `db_instance_type` consistency with other variables 