### PR TITLE
Update readme to reflect naming change

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ output "redis_url" {
 }
 
 output "ec2_instance_public_dns_name" {
-  value = module.terraform-seqera-module.ec2_instance_public_dns_name
+  value = module.terraform-seqera-aws.ec2_instance_public_dns_name
 }
 ```
 
@@ -128,7 +128,7 @@ output "redis_url" {
 }
 
 output "ec2_instance_public_dns_name" {
-  value = module.terraform-seqera-module.ec2_instance_public_dns_name
+  value = module.terraform-seqera-aws.ec2_instance_public_dns_name
 }
 ```
 
@@ -162,7 +162,7 @@ output "redis_url" {
 }
 
 output "ec2_instance_id" {
-  value = module.terraform-seqera-module.ec2_instance_id
+  value = module.terraform-seqera-aws.ec2_instance_id
 }
 ```
 


### PR DESCRIPTION
While testing the module, we discovered that the default values in some of the example code were incorrect and caused the plan to fail. This just corrects the instances of those, so people using the documentation don't run into this issue. 