### PR TITLE
[no issue]Update aws provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.0.0"
+      version = ">= 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
This pull request updates the version constraint for the AWS provider in our Terraform configuration after the issue reported on slack [here](https://seqera.slack.com/archives/C03117E4RAB/p1706127990908119) . 

```
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints >= 3.0.0, >= 3.29.0, >= 4.0.0, >= 4.18.0, >= 4.21.0, >= 4.33.0, >= 4.57.0, >= 4.66.0, >= 5.0.0, 5.0.0, >=
│ 5.20.0
╵
```

The goal is to ensure compatibility with a wider range of AWS provider versions.

The previous version constraint was fixed at `5.0.0`, which might limit our ability to newer features and improvements introduced in later versions of the AWS provider. By allowing versions greater than or equal to `5.0.0`fixes the above error and also we can stay up-to-date with the latest enhancements and bug fixes. 

I have tested these changes locally to ensure that our Terraform configurations work as expected with the updated AWS provider constraint.
