### PR TITLE
Allow create eks cluster creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ module "terraform-seqera-aws" {
   vpc_name = "my-seqera-tf-vpc"
 
   ## EKS
+  create_eks_cluster  = true
   cluster_name    = "my-seqera-tf-cluster"
   cluster_version = "1.27"
   eks_managed_node_group_defaults_instance_types = ["t3.medium"]


### PR DESCRIPTION
Noticed that the readme is missing the EKS cluster creation flag , and because of that `main.tf ` was not creating the eks cluster. 